### PR TITLE
add function to check if a point is in a sand trap

### DIFF
--- a/players/g1_player.py
+++ b/players/g1_player.py
@@ -452,13 +452,13 @@ def test_is_in_sand_trap():
             "point": (5,5),
             "sand_traps": [],  # empty to test if cache is checked
             "cache": {(5,5)},
-            "expect": False
+            "expect": True
         }
     ]
 
     for tc in cases:
         sand_trap_matplot_polys = [sympy_poly_to_mpl(poly) for poly in tc["sand_traps"]]
-        cache = set() if "cahce" not in tc else tc["cache"]
+        cache = set() if "cache" not in tc else tc["cache"]
         ans = is_in_sand_trap(tc["point"], sand_trap_matplot_polys, cache)
 
         assert ans == tc["expect"]


### PR DESCRIPTION
# Description

Made the following changes:

1. during map initialization
    - calculate all generated map points that are in a sand trap, and store in a set (on the Player instance's `map_points_in_sand_trap` property)
    - convert sand trap `Polygon`s to matlab `Path` for future use (`contains_point` method is faster on `Path`), on the Player instance's `sand_trap_matlab_polys` property
2. added the helper function `is_in_sand_trap(point: Tuple[float, float], sand_traps: List[Path], cache: Set[Tuple[float, float]] = set()) -> bool` to determine if a point is in a sand trap

```python
# example usage: check if the current location is in a sand trap
if is_in_sand_trap(curr_loc.coordinates, self.sand_trap_matlab_polys, cache=self.map_points_in_sand_trap):
    self.logger.debug("shooting from sand trap!")
else:
   self.logger.debug("shooting from green grass!")
```



# How has this been tested

Unit tests for `is_in_sand_trap` and `find_map_points_in_sand_trap` passed.
After adding the python snippet above, the debugging message match our expectation:

<img width="1637" alt="image" src="https://user-images.githubusercontent.com/25857014/190537052-b059f8ee-d13b-4971-84c6-ac5a53f7c70d.png">

<img width="1156" alt="image" src="https://user-images.githubusercontent.com/25857014/190537158-efcd0c05-2685-4a32-a586-23866d42dd7a.png">