### PR TITLE
Player/initial reachable

### DIFF
--- a/players/g1_player.py
+++ b/players/g1_player.py
@@ -254,25 +254,6 @@ class Player:
     def _max_sandtrap_ddist_ppf(self, conf:float):
         return self.max_sandtrap_ddist.ppf(1.0-conf)
 
-    '''
-    def reachable_point(self, current_point: Tuple[float, float], target_point: Tuple[float, float], conf: float, in_sandtrap: bool) -> bool:
-        """Determine whether the point is reachable with confidence [conf] based on our player's skill"""
-        if type(current_point) == Point2D:
-            current_point = tuple(current_point)
-        if type(target_point) == Point2D:
-            target_point = tuple(target_point)
-
-        current_point = np.array(current_point).astype(float)
-        target_point = np.array(target_point).astype(float)
-
-        if in_sandtrap:
-
-            return np.linalg.norm(current_point - target_point) <= self._max_sandtrap_ddist_ppf(conf)
-
-        else:
-            return np.linalg.norm(current_point - target_point) <= self._max_ddist_ppf(conf)
-        '''
-
     def splash_zone_within_polygon(self, current_point: Tuple[float, float], target_point: Tuple[float, float], conf: float) -> bool:
         if type(current_point) == Point2D:
             current_point = tuple(Point2D)

--- a/players/g1_player.py
+++ b/players/g1_player.py
@@ -319,7 +319,7 @@ class Player:
 
             # Add adjacent points to heap
             reachable_points, goal_dists = self.numpy_adjacent_and_dist(
-                next_p, conf, is_in_sand_trap(next_p, self.sand_trap_matlab_polys))
+                next_p, conf, is_in_sand_trap(next_p, self.sand_trap_matlab_polys, cache=self.map_points_in_sand_trap))
 
             for i in range(len(reachable_points)):
                 candidate_point = tuple(reachable_points[i])

--- a/players/g1_player.py
+++ b/players/g1_player.py
@@ -50,7 +50,6 @@ def splash_zone(distance: float, angle: float, conf: float, skill: int, current_
             conf_points) * (distance / skill) * 2 + distance / 2
         angles = np.vectorize(standard_ppf)(
             conf_points) * (1/(2*skill)) * 2 + angle
-        print("YES SAND")
     else:
         distances = np.vectorize(standard_ppf)(
             conf_points) * (distance / skill) + distance
@@ -299,13 +298,11 @@ class Player:
             distance_mask = cloc_distances <= self._max_sandtrap_ddist_ppf(conf)
             reachable_points = self.np_map_points[distance_mask]
             goal_distances = self.np_goal_dist[distance_mask]
-            print(in_sandtrap)
 
         else:
             distance_mask = cloc_distances <= self._max_ddist_ppf(conf)
             reachable_points = self.np_map_points[distance_mask]
             goal_distances = self.np_goal_dist[distance_mask]
-            print("NO SAND")
 
         return reachable_points, goal_distances
 
@@ -340,17 +337,9 @@ class Player:
                 return next_sp.point
 
             # Add adjacent points to heap
-            #print("next point", next_p)
-            #temp = (403.0, 537.0)
-
-           # print("method temp", is_in_sand_trap(temp, self.sand_trap_matlab_polys))
-
-            #print("temp manual", temp in self.map_points_in_sand_trap)
-            #print(self.map_points_in_sand_trap)
             reachable_points, goal_dists = self.numpy_adjacent_and_dist(
                 next_p, conf, is_in_sand_trap(next_p, self.sand_trap_matlab_polys))
-            #print(next_p)
-            #print(reachable_points)
+
             for i in range(len(reachable_points)):
                 candidate_point = tuple(reachable_points[i])
                 goal_dist = goal_dists[i]
@@ -361,8 +350,6 @@ class Player:
                     # if not self.splash_zone_within_polygon(new_point.previous.point, new_point.point, conf):
                     #     continue
                     best_cost[new_point.point] = new_point.actual_cost
-                    #print(next_p)
-                    #print(new_point)
                     heapq.heappush(heap, new_point)
 
         # No path available


### PR DESCRIPTION
Able to be merged with player/initial: 

I have added  _max_sandtrap_ddist_ppf() method that will calculate the players ability to make a distance shot with certain confidence from a sand trap, this method is functionally the same as _max_ddist_ppf(), but just accounts for the sand trap variability.

Additionally I modified the numpy_adjacent_and_dist method to account for only finding points that are reachable from the current location (accounting for sand traps). The next_target method has accordingly been modified to work with these changes

As you can see without this working method, the A* would try to take shots that the player is not capable of from a sand trap: 
<img width="946" alt="Screen Shot 2022-09-19 at 6 31 48 PM" src="https://user-images.githubusercontent.com/90356066/191133397-1f06d781-d849-47e8-926c-13418ff4470b.png">

but with the newly working search the player is able to find a viable path:


<img width="1096" alt="Screen Shot 2022-09-19 at 6 34 06 PM" src="https://user-images.githubusercontent.com/90356066/191133430-9a64a8a3-e29d-4933-bdb9-f6401cd61263.png">


