### PR TITLE
consider rolling when calculating reachable points

### DIFF
--- a/players/g1_player.py
+++ b/players/g1_player.py
@@ -210,7 +210,7 @@ class ScoredPoint:
 
 
 class Player:
-    AVOID_SAND_PENALTY = 2
+    AVOID_SAND_PENALTY = 0.1
 
     def __init__(self, skill: int, rng: np.random.Generator, logger: logging.Logger, golf_map: sympy.Polygon, start: sympy.geometry.Point2D, target: sympy.geometry.Point2D, sand_traps: List[sympy.Polygon], map_path: str, precomp_dir: str) -> None:
         """Initialise the player with given skill.

--- a/players/g1_player.py
+++ b/players/g1_player.py
@@ -140,6 +140,8 @@ def find_map_points_in_sand_trap(map_points: List[Tuple[float, float]], sand_tra
 
     return points_in_sand_trap
 
+def roll(src: Tuple[float, float], dst: Tuple[float, float], rolling_factor: float) -> Tuple[float, float]:
+    return dst
 
 class ScoredPoint:
     """Scored point class for use in A* search algorithm"""
@@ -329,8 +331,9 @@ class Player:
                 return next_sp.point
 
             # Add adjacent points to heap
+            next_p_after_rolling = next_p if next_sp.previous is None else roll(next_sp.previous.point, next_p, 1.1)
             reachable_points, goal_dists = self.numpy_adjacent_and_dist(
-                next_p, conf, is_in_sand_trap(next_p, self.sand_trap_matlab_polys, cache=self.map_points_in_sand_trap))
+                next_p_after_rolling, conf, is_in_sand_trap(next_p, self.sand_trap_matlab_polys, cache=self.map_points_in_sand_trap))
 
             for i in range(len(reachable_points)):
                 candidate_point = tuple(reachable_points[i])


### PR DESCRIPTION
# Description

We realized that rolling wasn't taken into consideration when calculating the reachable points, after seeing the weird behavior of our player on the map below with skill level set to 85 using commit 38f0bfbe5183f520f24f0082ea00e1277d431cd6:

```python
python main.py --map maps/g1/test_avoid_sandtrap.json --players 1 6 --seed 85 --skill 85
```
<img width="1787" alt="image" src="https://user-images.githubusercontent.com/25857014/191384061-0d176865-25e0-41a7-a3c8-5aab861b326b.png">

- expected behavior: player aim for a point before sand trap and make a shot to cross the sand trap
- actual behavior: player aimed for a point in the sand trap

- why this happened?
  The further you could go without risking rolling into the sand trap is x:245. From there, it's impossible to make a single shot to cross the sand. However, it's possible when you consider the rolling, where you might actually end up in 245 * 1.1 = 270.

After rolling is considered, the player is behaving as expected:

<img width="1685" alt="image" src="https://user-images.githubusercontent.com/25857014/191389380-b8cbacd7-1d2e-4847-ac39-ea086c2afc2f.png">

# Is penalty really needed?

Applying a penalty of 0 shows the following result:

<img width="1629" alt="image" src="https://user-images.githubusercontent.com/25857014/191389841-9d7f9d7d-4b5d-4ec6-b698-7a7a97a989a3.png">

<img width="1650" alt="image" src="https://user-images.githubusercontent.com/25857014/191389881-d01c0597-aced-4eb2-a7f0-e7cf16ee2586.png">

Applying a penalty of 0.1 gives a similar result. **I'll change the default penalty value to 0.1**, to force A* search explore points of type A over type B:

- type A: near sand trap and splash zone won't intersect sand trap
- type B: near sand trap and has possibility of rolling into sand trap

The penalty is actually not what makes the player shoot in a way that balls don't roll into sand trap. The deciding factor is that after rolling, if a ball ends in a sand trap, its reachable points cover a significantly smaller region due to the halved distance rating.


# More testing

## skill level 75

<img width="1590" alt="image" src="https://user-images.githubusercontent.com/25857014/191390707-04f5d652-ef91-48c4-9f57-f91f9c725b31.png">

<img width="1646" alt="image" src="https://user-images.githubusercontent.com/25857014/191390766-6a060614-b929-4962-b7f0-2f5d33c93bdd.png">

## skill level 90

<img width="1616" alt="image" src="https://user-images.githubusercontent.com/25857014/191390841-b3c69e08-222f-42b3-920d-95238d58ce84.png">

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/25857014/191390861-38ab9306-1768-4a9d-8e73-f300585bcec0.png">