### PR TITLE
Player/initial sand fixes corrected

### DIFF
--- a/players/g1_player.py
+++ b/players/g1_player.py
@@ -302,10 +302,10 @@ class Player:
         splash_in_poly = self.shapely_poly.contains(ShapelyPolygon(splash_zone_poly_points))
 
         splash_in_sand = False
-
         for sand_trap in self.sand_trap_shapely_polys:
             if sand_trap.intersects(ShapelyPolygon(splash_zone_poly_points)):
                 splash_in_sand = True
+                break
 
         return [splash_in_poly, splash_in_sand]
 

--- a/players/g1_player.py
+++ b/players/g1_player.py
@@ -377,7 +377,18 @@ class Player:
                 return next_sp.point
 
             # Add adjacent points to heap
-            next_p_after_rolling = next_p if next_sp.previous is None else roll(next_sp.previous.point, next_p, constants.extra_roll)
+            if next_sp.previous is None:
+                next_p_after_rolling = next_p
+            elif is_in_sand_trap(next_p, self.sand_trap_matlab_polys, cache=self.map_points_in_sand_trap):
+                next_p_after_rolling = next_p
+            elif np.linalg.norm(np.array(self.goal) - np.array(next_sp.previous.point)) < 20:
+                if not is_in_sand_trap(next_sp.previous.point, self.sand_trap_matlab_polys, cache=self.map_points_in_sand_trap):
+                    next_p_after_rolling = next_p
+            else:
+                next_p_after_rolling = roll(next_sp.previous.point, next_p, constants.extra_roll)
+
+            #next_p_after_rolling = next_p if next_sp.previous is None else roll(next_sp.previous.point, next_p, constants.extra_roll)
+
             reachable_points, goal_dists = self.numpy_adjacent_and_dist(
                 next_p_after_rolling, conf, is_in_sand_trap(next_p_after_rolling, self.sand_trap_matlab_polys, cache=self.map_points_in_sand_trap))
 


### PR DESCRIPTION
Keeps optimization for time by putting the sandtrap and polygone zone calculations in one method returning a list of booleans. Additionally, shows fixes for accounting for rolling in putting shots and rolling from sand trap shots. Initially, with no optimizations for these shots, we see: 
<img width="1018" alt="Screen Shot 2022-09-24 at 3 16 10 PM" src="https://user-images.githubusercontent.com/90356066/192118960-bcd8056b-d540-4048-8bd6-0ba061ef9a56.png">

> - Before the fix, our algorithm incorrectly adds rolling even if target point is in a sand trap. Thus, the player aims at points in the sand trap thinking that it would eventually end up in the green.
> - After the fix, you can see that the player aims for points on the green instead, since that would yield a strategy requiring fewer number of shots to the destination.

But now to account for no rolling in sand traps and puts we see: 
<img width="1034" alt="Screen Shot 2022-09-24 at 3 25 49 PM" src="https://user-images.githubusercontent.com/90356066/192118971-2034dc2b-486e-4346-8441-19db3766b8e6.png">


Additionally, I corrected the code such that shots that are purposely aiming for a sand trap are not double penalized, showing why the player chose to aim for a further sandtrap:


<img width="1035" alt="Screen Shot 2022-09-24 at 3 41 16 PM" src="https://user-images.githubusercontent.com/90356066/192118994-f7c23077-ff11-420f-9521-ae3a09ac3fa1.png">


Lastly, I corrected a condition in the play method that checked for rolling to account for the case in which the ball is closer than 20 m but is coming from a sandtrap
